### PR TITLE
Do not emit an empty line

### DIFF
--- a/command.php
+++ b/command.php
@@ -1,4 +1,3 @@
-
 <?php
 
 if (!class_exists('WP_CLI')) {


### PR DESCRIPTION
On every WP-CLI run this empty line appears ruining the output.